### PR TITLE
Fix toggle overloading bug

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -67,14 +67,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </head>
 <body>
 
-  <polymer-element name="x-trigger" extends="paper-icon-button" relative on-tap="{{toggle}}" noink>
+  <polymer-element name="x-trigger" extends="paper-icon-button" relative on-tap="{{toggleDropdown}}" noink>
   <template>
     <shadow></shadow>
     <content></content>
   </template>
   <script>
     Polymer({
-      toggle: function() {
+      toggleDropdown: function() {
         if (!this.dropdown) {
           this.dropdown = this.querySelector('paper-dropdown');
         }


### PR DESCRIPTION
I was wondering why the ugly grey toggle was being applied to these buttons, turns out paper-button-base was looking to see whether toggle was set on the element (it has an "if (this.toggle)") but paper-dropdown overloaded toggle with the a function, causing "if (this.toggle)" to resolve to true due to JS's lack of type system.

Either way, renaming the on-tap event here to anything other than toggle (I chose toggleDropdown) fixes the issue.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/polymer/paper-dropdown/12)

<!-- Reviewable:end -->
